### PR TITLE
Downgraded Microsoft.Data.SQLite package

### DIFF
--- a/source/IL2CPU.Debug.Symbols/IL2CPU.Debug.Symbols.csproj
+++ b/source/IL2CPU.Debug.Symbols/IL2CPU.Debug.Symbols.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper.StrongName" Version="1.50.2" />
         <PackageReference Include="DapperExtensions.StrongName" Version="1.50.2" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
         <PackageReference Include="Microsoft.DiaSymReader" Version="1.1.0" />
         <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.2.0" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.8" />


### PR DESCRIPTION
Hi, it's @Arawn-Davies but I'm on my alternative account, Downgraded the Microsoft.Data.SQLite package to get rid of that annoying e_sqlite3 missing error, doesn't have any effect on anything else so feel free to merge :)